### PR TITLE
Add initial Supabase schema, policies, and triggers

### DIFF
--- a/backend/supabase/policies.sql
+++ b/backend/supabase/policies.sql
@@ -1,0 +1,68 @@
+-- policies.sql — Row-Level Security for ExploreAfrica Platform
+
+-- Enable RLS for all relevant tables
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE bookings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reviews ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE support_tickets ENABLE ROW LEVEL SECURITY;
+
+-- User: Can only see their own user record
+CREATE POLICY "Users can view their own profile" ON users
+  FOR SELECT USING (auth.uid()::text = user_id::text);
+
+-- Bookings: User can manage their own bookings
+CREATE POLICY "User can view own bookings" ON bookings
+  FOR SELECT USING (auth.uid()::text = user_id::text);
+
+CREATE POLICY "User can insert own booking" ON bookings
+  FOR INSERT WITH CHECK (auth.uid()::text = user_id::text);
+
+CREATE POLICY "User can update own booking" ON bookings
+  FOR UPDATE USING (auth.uid()::text = user_id::text);
+
+-- Messages: Sender or Receiver can view
+CREATE POLICY "User can read their messages" ON messages
+  FOR SELECT USING (
+    auth.uid()::text = sender_id::text OR auth.uid()::text = receiver_id::text
+  );
+
+-- Messages: Only sender can write
+CREATE POLICY "User can send message" ON messages
+  FOR INSERT WITH CHECK (auth.uid()::text = sender_id::text);
+
+-- Conversations: Show if user is involved via messages
+CREATE POLICY "User can view related conversations" ON conversations
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM messages
+      WHERE messages.conversation_id = conversations.conversation_id
+      AND (messages.sender_id::text = auth.uid()::text OR messages.receiver_id::text = auth.uid()::text)
+    )
+  );
+
+-- Reviews: Only reviewers can see their own or public
+CREATE POLICY "User can view own review" ON reviews
+  FOR SELECT USING (auth.uid()::text = user_id::text);
+
+CREATE POLICY "User can create review" ON reviews
+  FOR INSERT WITH CHECK (auth.uid()::text = user_id::text);
+
+-- Payments: View own
+CREATE POLICY "User can view their own payments" ON payments
+  FOR SELECT USING (
+    auth.uid()::text = (
+      SELECT user_id FROM bookings WHERE bookings.booking_id = payments.booking_id
+    )::text
+  );
+
+-- Support Tickets: Submit and view own
+CREATE POLICY "User can view their own tickets" ON support_tickets
+  FOR SELECT USING (auth.uid()::text = user_id::text);
+
+CREATE POLICY "User can submit ticket" ON support_tickets
+  FOR INSERT WITH CHECK (auth.uid()::text = user_id::text);
+
+-- Admin/Staff override logic can be added later with roles or separate table joins

--- a/backend/supabase/schema.sql
+++ b/backend/supabase/schema.sql
@@ -1,0 +1,198 @@
+-- ===========================
+-- SCHEMA.SQL
+-- ===========================
+
+-- Enable UUID extension for future use
+create extension if not exists "uuid-ossp";
+
+-- USERS TABLE
+create table users (
+  user_id uuid primary key default uuid_generate_v4(),
+  first_name varchar(50) not null,
+  last_name varchar(50) not null,
+  email varchar(100) unique not null,
+  password_hash varchar(255) not null,
+  phone_number varchar(20),
+  country varchar(50),
+  user_role text check (user_role in ('customer', 'admin', 'staff')) default 'customer',
+  created_at timestamp default current_timestamp,
+  updated_at timestamp default current_timestamp
+);
+
+-- DESTINATIONS
+create table destinations (
+  destination_id serial primary key,
+  name varchar(100) not null,
+  country varchar(50) not null,
+  region_park_id varchar(100),
+  description text,
+  image_url varchar(255),
+  coordinates point,
+  active boolean default true
+);
+
+-- ACCOMMODATIONS
+create table accommodations (
+  accommodation_id serial primary key,
+  destination_id int references destinations(destination_id),
+  name varchar(100) not null,
+  owner_id uuid references users(user_id),
+  accommodation_type text check (accommodation_type in ('lodge', 'tent', 'hotel', 'camp')),
+  price_per_night numeric(10,2) not null,
+  max_capacity int not null,
+  contact_info varchar(100),
+  website_url varchar(255),
+  address varchar(255),
+  latitude decimal(9,6),
+  longitude decimal(9,6),
+  amenities json,
+  rating_avg decimal(2,1),
+  rating_count int
+);
+
+-- ACCOMMODATION IMAGES
+create table accommodation_images (
+  image_id serial primary key,
+  accommodation_id int references accommodations(accommodation_id),
+  url varchar(255),
+  caption varchar(255)
+);
+
+-- SAFARI PACKAGES
+create table packages (
+  package_id serial primary key,
+  destination_id int references destinations(destination_id),
+  package_name varchar(100) not null,
+  description text,
+  price_per_person numeric(10,2) not null,
+  duration_days int not null,
+  active boolean default true
+);
+
+-- PACKAGE IMAGES
+create table package_images (
+  image_id serial primary key,
+  package_id int references packages(package_id),
+  url varchar(255),
+  caption varchar(255)
+);
+
+-- BOOKINGS
+create table bookings (
+  booking_id serial primary key,
+  user_id uuid references users(user_id),
+  package_id int references packages(package_id),
+  accommodation_id int references accommodations(accommodation_id),
+  num_of_guests int not null,
+  total_amount numeric(10,2) not null,
+  booking_status text check (booking_status in ('pending', 'confirmed', 'cancelled', 'completed')) default 'pending',
+  booking_date timestamp default current_timestamp,
+  check_in_date date,
+  check_out_date date,
+  travel_date date not null,
+  nights int,
+  confirmation_number varchar(100) unique,
+  cancel_reason text,
+  modified_at timestamp default current_timestamp
+);
+
+-- PAYMENTS
+create table payments (
+  payment_id serial primary key,
+  booking_id int references bookings(booking_id),
+  package_id int references packages(package_id),
+  amount_paid numeric(10,2) not null,
+  payment_date timestamp default current_timestamp,
+  payment_method text check (payment_method in ('credit_card', 'PayPal', 'wire_transfer', 'mobile_money')),
+  transaction_ref varchar(100) unique,
+  payment_status text check (payment_status in ('pending', 'successful', 'failed')),
+  currency char(3),
+  processing_fee numeric(10,2),
+  refund_status text check (refund_status in ('not_refunded', 'pending', 'refunded')),
+  refund_date timestamp
+);
+
+-- ITINERARIES
+create table itineraries (
+  itinerary_id serial primary key,
+  package_id int references packages(package_id),
+  day_number int,
+  activity_description text,
+  location varchar(100)
+);
+
+-- AVAILABILITY
+create table availability (
+  availability_id serial primary key,
+  accommodation_id int references accommodations(accommodation_id),
+  package_id int references packages(package_id),
+  start_date date not null,
+  end_date date,
+  available_units int,
+  status text check (status in ('available', 'blocked')),
+  block_reason varchar(255),
+  created_by uuid references users(user_id),
+  created_at timestamp default current_timestamp
+);
+
+-- SEASONAL PRICING
+create table seasonal_pricing (
+  pricing_id serial primary key,
+  accommodation_id int references accommodations(accommodation_id),
+  package_id int references packages(package_id),
+  start_date date not null,
+  end_date date,
+  price numeric(10,2) not null,
+  created_by uuid references users(user_id),
+  created_at timestamp default current_timestamp
+);
+
+-- CONVERSATIONS
+create table conversations (
+  conversation_id serial primary key,
+  package_id int references packages(package_id),
+  booking_id int references bookings(booking_id),
+  created_at timestamp default current_timestamp
+);
+
+-- MESSAGES
+create table messages (
+  message_id serial primary key,
+  conversation_id int references conversations(conversation_id),
+  sender_id uuid references users(user_id),
+  receiver_id uuid references users(user_id),
+  body text,
+  sent_at timestamp default current_timestamp,
+  read_at timestamp
+);
+
+-- REVIEWS
+create table reviews (
+  review_id serial primary key,
+  user_id uuid references users(user_id),
+  package_id int references packages(package_id),
+  booking_id int references bookings(booking_id),
+  rating int check (rating between 1 and 5),
+  comments text,
+  review_date timestamp default current_timestamp,
+  response_text text,
+  response_date timestamp,
+  responded_by uuid references users(user_id),
+  response_status text check (response_status in ('pending', 'published')),
+  helpful_count int
+);
+
+-- SUPPORT TICKETS
+create table support_tickets (
+  ticket_id serial primary key,
+  user_id uuid references users(user_id),
+  subject varchar(150) not null,
+  description text,
+  status text check (status in ('open', 'closed', 'pending')),
+  created_at timestamp default current_timestamp,
+  assigned_to uuid references users(user_id),
+  priority text check (priority in ('low', 'medium', 'high')),
+  last_updated_at timestamp,
+  closed_at timestamp,
+  resolution_notes text
+);

--- a/backend/supabase/triggers.sql
+++ b/backend/supabase/triggers.sql
@@ -1,0 +1,21 @@
+-- triggers.sql — Supabase Auth Sync
+
+-- Trigger Function: Insert user into 'users' table after signup
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO users (user_id, email, created_at)
+  VALUES (NEW.id, NEW.email, NOW());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger: After insert on 'auth.users'
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Notes:
+-- 1. This assumes 'user_id' in 'users' table matches 'auth.users.id'
+-- 2. You can extend 'handle_new_user' to populate name, role, etc.
+-- 3. Make sure your 'users' table's 'user_id' is of type UUID to match auth.users


### PR DESCRIPTION
What’s Included:
**schema.sql:** Full PostgreSQL-compatible schema for all core entities (users, bookings, accommodations, payments, etc.)
**policies.sql:** Row-Level Security (RLS) policies to restrict access based on user roles (e.g., users can only access their own bookings/messages)
**triggers.sql:** Trigger to sync Supabase auth.users into the internal users table on signup
